### PR TITLE
Toast 알림 추가

### DIFF
--- a/src/main/java/com/dmk/melodify/common/security/CustomLogoutSuccessHandler.java
+++ b/src/main/java/com/dmk/melodify/common/security/CustomLogoutSuccessHandler.java
@@ -1,0 +1,52 @@
+package com.dmk.melodify.common.security;
+
+import com.dmk.melodify.common.util.UrlEncoderUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+
+        String referer = request.getHeader("REFERER");
+        log.debug("로그아웃 요청이 들어온 주소: {}", referer);
+
+        String requestType = referer.substring(referer.lastIndexOf("/") + 1);
+        log.debug("어떤 api에서 요청이 들어왔는가: {}", requestType);
+
+
+        // toastr 알림 메세지 생성
+        String title = "";
+        String message = "";
+        switch (requestType) {
+            case "delete" -> {
+                title = UrlEncoderUtil.encode("%s".formatted("회원탈퇴 성공!"));
+                message = UrlEncoderUtil.encode("%s".formatted("아쉽지만 보내드릴게요.."));
+            }
+            case "modify-password" -> {
+                title = UrlEncoderUtil.encode("%s".formatted("비밀번호 변경 성공!"));
+                message = UrlEncoderUtil.encode("%s".formatted("변경된 비밀번호로 다시 로그인 해주세요!"));
+            }
+            default -> {
+                title = UrlEncoderUtil.encode("%s".formatted("로그아웃 성공!"));
+                message = UrlEncoderUtil.encode("%s".formatted("다시 와주실 거죠..?"));
+            }
+        }
+
+        String redirectUrl = "/?title=%s&message=%s".formatted(title, message);
+        log.debug("redirectUrl: {}", redirectUrl);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/com/dmk/melodify/common/security/SecurityConfig.java
+++ b/src/main/java/com/dmk/melodify/common/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.dmk.melodify.common.security;
 
+import com.dmk.melodify.common.util.UrlEncoderUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,7 +26,10 @@ public class SecurityConfig {
                 )
                 .logout(logout -> logout
                         .logoutUrl("/members/logout")
-                        .logoutSuccessUrl("/")
+                        .logoutSuccessUrl("/?title=%s&message=%s".formatted(
+                                UrlEncoderUtil.encode("%s".formatted("회원탈퇴 성공!")),
+                                UrlEncoderUtil.encode("%s".formatted("아쉽지만 보내드릴게요..")))
+                        )
                         .invalidateHttpSession(true)
                         .deleteCookies("JSESSIONID")
                 )

--- a/src/main/java/com/dmk/melodify/common/security/SecurityConfig.java
+++ b/src/main/java/com/dmk/melodify/common/security/SecurityConfig.java
@@ -1,17 +1,25 @@
 package com.dmk.melodify.common.security;
 
 import com.dmk.melodify.common.util.UrlEncoderUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,12 +34,9 @@ public class SecurityConfig {
                 )
                 .logout(logout -> logout
                         .logoutUrl("/members/logout")
-                        .logoutSuccessUrl("/?title=%s&message=%s".formatted(
-                                UrlEncoderUtil.encode("%s".formatted("회원탈퇴 성공!")),
-                                UrlEncoderUtil.encode("%s".formatted("아쉽지만 보내드릴게요..")))
-                        )
                         .invalidateHttpSession(true)
                         .deleteCookies("JSESSIONID")
+                        .logoutSuccessHandler(customLogoutSuccessHandler)
                 )
                 .build();
     }

--- a/src/main/java/com/dmk/melodify/common/util/UrlEncoderUtil.java
+++ b/src/main/java/com/dmk/melodify/common/util/UrlEncoderUtil.java
@@ -1,0 +1,11 @@
+package com.dmk.melodify.common.util;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class UrlEncoderUtil {
+    public static String encode(String str) {
+        return URLEncoder.encode(str, StandardCharsets.UTF_8);
+    }
+
+}

--- a/src/main/java/com/dmk/melodify/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dmk/melodify/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.dmk.melodify.domain.member.controller;
 
 import com.dmk.melodify.common.security.MemberContext;
+import com.dmk.melodify.common.util.UrlEncoderUtil;
 import com.dmk.melodify.domain.member.dto.DeleteDto;
 import com.dmk.melodify.domain.member.dto.JoinForm;
 import com.dmk.melodify.domain.member.dto.ModifyDto;
@@ -79,6 +80,8 @@ public class MemberController {
     @PostMapping("/join")
     public String join(JoinForm joinForm) {
         memberService.join(joinForm);
-        return "redirect:/members/login";
+        String title = UrlEncoderUtil.encode("%s".formatted("회원가입 성공"));
+        String message = UrlEncoderUtil.encode("%s".formatted("로그인 후 멜로디파이를 이용해주세요!"));
+        return "redirect:/members/login?title=%s&message=%s".formatted(title, message);
     }
 }

--- a/src/main/resources/static/js/toastr/success.js
+++ b/src/main/resources/static/js/toastr/success.js
@@ -16,6 +16,6 @@ toastr.options = {
     hideMethod: "fadeOut",
 };
 
-function loginSuccessAlert(title, message) {
+function successAlert(title, message) {
     toastr["success"](message, title);
 }

--- a/src/main/resources/static/js/toastr/success.js
+++ b/src/main/resources/static/js/toastr/success.js
@@ -1,0 +1,21 @@
+toastr.options = {
+    closeButton: false,
+    debug: false,
+    newestOnTop: false,
+    progressBar: true,
+    positionClass: "toast-top-right",
+    preventDuplicates: false,
+    onclick: null,
+    showDuration: "300",
+    hideDuration: "1000",
+    timeOut: "2000",
+    extendedTimeOut: "1000",
+    showEasing: "swing",
+    hideEasing: "linear",
+    showMethod: "fadeIn",
+    hideMethod: "fadeOut",
+};
+
+function loginSuccessAlert(title, message) {
+    toastr["success"](message, title);
+}

--- a/src/main/resources/templates/home/index.html
+++ b/src/main/resources/templates/home/index.html
@@ -1,5 +1,14 @@
 <html lang="ko" layout:decorate="~{layout/layout}">
 <main layout:fragment="main">
     <h2>멜로디파이!</h2>
+
+    <script th:src="@{/js/toastr/success.js}"></script>
+    <script th:inline="javascript" defer>
+        const params = /*[[${param}]]*/ null;
+
+        if (params.title && params.message) {
+            successAlert(params.title, params.message);
+        }
+    </script>
 </main>
 </html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -8,9 +8,17 @@
     <meta name="author" content="Dongmin Kim">
     <title layout:title-pattern="$LAYOUT_TITLE | $CONTENT_TITLE">Melodify</title>
 
-    <!-- bootstarp 5   -->
+    <!-- jquery -->
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
+
+    <!-- bootstarp 5 -->
     <script th:src="@{/bootstrap/bootstrap.min.js}"></script>
     <link rel="stylesheet" th:href="@{/bootstrap/bootstrap.min.css}">
+
+    <!-- toastr -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"/>
+
 </head>
 <body class="d-flex flex-column min-vh-100">
     <header class="p-3 bg-dark text-white">

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -22,6 +22,15 @@
         </form>
     </div>
 
+    <script th:src="@{/js/toastr/success.js}"></script>
+    <script th:inline="javascript" defer>
+        const params = /*[[${param}]]*/ null;
+
+        if (params.title && params.message) {
+            loginSuccessAlert(params.title, params.message);
+        }
+    </script>
+
     <script>
         function loginFormSubmit(form) {
             const username = form.username.value.trim();

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -27,7 +27,7 @@
         const params = /*[[${param}]]*/ null;
 
         if (params.title && params.message) {
-            loginSuccessAlert(params.title, params.message);
+            successAlert(params.title, params.message);
         }
     </script>
 


### PR DESCRIPTION
## ✨ 관련 이슈
- #18 

## ✅ 작업 상세 내용
- 로그아웃 핸들러에서 리다이렉트가 `/members/logout`인 요청을 분기해서 처리하도록 구현
- [x] 로그아웃 핸들러 구현
- [x] toastr 추가

## 📌 특이사항
- 쿼리 파라미터로 보내는 방식은 url이 너무 길어지는 것 같음. 좀 더 깔끔한 방식이 있는지 찾아보기

## 📃 참고 레퍼런스
- [이전 페이지 url 확인하는 방법](https://kms0209.tistory.com/49)
- [로그아웃 핸들러 구현](https://anjoliena.tistory.com/6)
- [url 인코딩](https://velog.io/@hth9876/URLEncoder.encode-URL%EC%9E%AC%EC%9E%91%EC%84%B1Rewriting)